### PR TITLE
Switch to single example repo for snippets

### DIFF
--- a/developer-resources/debug-reverted-transactions.md
+++ b/developer-resources/debug-reverted-transactions.md
@@ -78,5 +78,5 @@ The example interface `Error(string)` is typically used when throwing a regular 
 
 ### Example Snippet
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-transaction-debug?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/transaction-debug?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 

--- a/developer-resources/how-to-build-on-vechain/connect-to-the-network.md
+++ b/developer-resources/how-to-build-on-vechain/connect-to-the-network.md
@@ -37,7 +37,7 @@ console.log("Genesis Block:", genesisBlock.number, genesisBlock.id);
 
 You can test the above snippet here:
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-connect?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/connect?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 {% hint style="info" %}
 The `ThorClient` provides a multitude of properties with access to all relevant functionality on VeChain. You can find examples and details about all of them in the [Thor Client docs](../../../developer-resources/sdks-and-providers/sdk/thor-client.md).

--- a/developer-resources/how-to-build-on-vechain/listen-to-changes/beats.md
+++ b/developer-resources/how-to-build-on-vechain/listen-to-changes/beats.md
@@ -84,7 +84,7 @@ console.log('Data found', bloomUtils.isInBloom(block.bloom, block.k, dataToTest)
 
 ## Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-listen-beats?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/listen-beats?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 Another example can be found on GitHub using a React Hook that listens and provides state updates when information is found in a new block. For example, transaction IDs or addresses:
 

--- a/developer-resources/how-to-build-on-vechain/listen-to-changes/blocks.md
+++ b/developer-resources/how-to-build-on-vechain/listen-to-changes/blocks.md
@@ -55,4 +55,4 @@ An example result is:
 
 ## Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-listen-blocks?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/listen-blocks?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-build-on-vechain/listen-to-changes/events.md
+++ b/developer-resources/how-to-build-on-vechain/listen-to-changes/events.md
@@ -139,4 +139,4 @@ Generic transaction details such as ID, block information, or the origin of the 
 
 ## Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-listen-events?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/listen-events?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-build-on-vechain/listen-to-changes/transactions.md
+++ b/developer-resources/how-to-build-on-vechain/listen-to-changes/transactions.md
@@ -32,4 +32,4 @@ const tx = await thor.transactions.getTransaction(addedTx.id, {
 
 ## Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-listen-transactions?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/listen-transactions?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-build-on-vechain/listen-to-changes/vet-transfers.md
+++ b/developer-resources/how-to-build-on-vechain/listen-to-changes/vet-transfers.md
@@ -61,4 +61,4 @@ The amount is a hexlified BigInt that can be converted into a BigInt using `BigI
 
 ## Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-listen-transfers?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/listen-transfers?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-build-on-vechain/read-data/events-and-logs.md
+++ b/developer-resources/how-to-build-on-vechain/read-data/events-and-logs.md
@@ -108,7 +108,7 @@ results.forEach(result => {
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-read-logs-filtereventlogs-nmyprl?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/read-logs-contract.load?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 ### `filterEventLogs()`: Multiple Events in one Request
 
@@ -210,5 +210,5 @@ The types of the results are fully documented in the [Event Logs Interface.](htt
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-read-logs-filterraweventlogs?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/read-logs-filterraweventlogs?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 

--- a/developer-resources/how-to-build-on-vechain/read-data/read-accounts.md
+++ b/developer-resources/how-to-build-on-vechain/read-data/read-accounts.md
@@ -25,7 +25,7 @@ const bytecode = await thor.accounts.getBytecode(
 
 Test it yourself:
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-read-account?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/read-account?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 Type definition and documentation of all attributes:
 

--- a/developer-resources/how-to-build-on-vechain/read-data/read-blocks.md
+++ b/developer-resources/how-to-build-on-vechain/read-data/read-blocks.md
@@ -32,7 +32,7 @@ console.log(expanded);
 
 Test it yourself:
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-read-block?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/read-block?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 Type definition and documentation of all attributes:
 

--- a/developer-resources/how-to-build-on-vechain/read-data/read-transactions.md
+++ b/developer-resources/how-to-build-on-vechain/read-data/read-transactions.md
@@ -40,7 +40,7 @@ console.log(txReceipt);
 
 Test it yourself:
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-read-transaction?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/read-transaction?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 Type definition and documentation of all attributes:
 

--- a/developer-resources/how-to-build-on-vechain/read-data/states-and-views.md
+++ b/developer-resources/how-to-build-on-vechain/read-data/states-and-views.md
@@ -77,7 +77,7 @@ If the transaction encounters an error, the method call will also throw an error
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-executecontractcall?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/contracts-executecall?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 ## contracts.load(address, abi)
 
@@ -133,4 +133,4 @@ console.log('Balance Past', balancePast);
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-contractloader-read?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/read-contract.load?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-build-on-vechain/read-data/vet-transfers.md
+++ b/developer-resources/how-to-build-on-vechain/read-data/vet-transfers.md
@@ -51,4 +51,4 @@ Type definition and documentation of all options and results:
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-filtertransferlogs?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/filtertransferlogs?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-build-on-vechain/write-data/fee-delegation.md
+++ b/developer-resources/how-to-build-on-vechain/write-data/fee-delegation.md
@@ -43,7 +43,7 @@ const walletWithAccountSponsor = new ProviderInternalBaseWallet(
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-transaction?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/transaction-execute?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 
 ## Sign as Delegator Service
 
@@ -73,4 +73,4 @@ const signature = `0x${Buffer.from(
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-delegation-service?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/delegation-service?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-build-on-vechain/write-data/transactions.md
+++ b/developer-resources/how-to-build-on-vechain/write-data/transactions.md
@@ -137,4 +137,4 @@ const txReceipt = await thor.transactions.waitForTransaction(
 
 ### Example Project
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-transaction?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/transaction-execute?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}

--- a/developer-resources/how-to-verify-address-ownership/README.md
+++ b/developer-resources/how-to-verify-address-ownership/README.md
@@ -102,5 +102,5 @@ catch (err) {
 
 ### Sign & Verify
 
-{% embed url="https://stackblitz.com/edit/vechain-sdk-certificate-sign?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
+{% embed url="https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/certificate?ctl=1&embed=1&file=index.mjs&hideExplorer=1&hideNavigation=1&view=editor" %}
 

--- a/developer-resources/how-to-verify-address-ownership/next.js-session-verification.md
+++ b/developer-resources/how-to-verify-address-ownership/next.js-session-verification.md
@@ -162,4 +162,4 @@ export default function handler(
 
 A Next.js example is available on StackBlitz:
 
-[https://stackblitz.com/edit/nextjs-dappkit-certificate?file=pages%2Fapi%2Fverify.ts](https://stackblitz.com/edit/nextjs-dappkit-certificate?file=pages%2Fapi%2Fverify.ts)
+[https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/nextjs-dappkit-certificate?file=pages%2Fapi%2Fverify.ts](https://stackblitz.com/github/vechain-energy/example-snippets/tree/v1.0.0/sdk/nextjs-dappkit-certificate?file=pages%2Fapi%2Fverify.ts)


### PR DESCRIPTION
The stackblitz links have been collected into a single example repository for improved maintenance.

They are dynamically imported from github when linked or embedded. The linking is using a tag to prevent accidental changes and to support easier changes for future updates.

I would like to share maintainer access to the repository access or move it to a different group, depending on your needs.