### PR TITLE
fix broken b32 link and pin graph-compiler package

### DIFF
--- a/developer-resources/how-to-build-on-vechain/read-data/events-and-logs.md
+++ b/developer-resources/how-to-build-on-vechain/read-data/events-and-logs.md
@@ -12,7 +12,7 @@ This example used below will utilize the VTHO contract, which manages VeChain's 
 
 * Smart Contract Address: `0x0000000000000000000000000000456e65726779`
 * The contract's source code can be found on GitHub at: [https://github.com/vechain/thor/blob/f58c17ae50f1ec8698d9daf6e05076d17dcafeaf/builtin/gen/energy.sol](https://github.com/vechain/thor/blob/f58c17ae50f1ec8698d9daf6e05076d17dcafeaf/builtin/gen/energy.sol)
-* This and many other Application Binary Interface (ABI) are available on b32, a repository that gathers publicly available interfaces for VeChain projects: [https://gitabihub.com/vechain/b32/blob/master/ABIs/energy.json](https://github.com/vechain/b32/blob/master/ABIs/energy.json), but feel free to use your own.
+* This and many other Application Binary Interface (ABI) are available on b32, a repository that gathers publicly available interfaces for VeChain projects: [https://github.com/vechain/b32/blob/master/ABIs/energy.json](https://github.com/vechain/b32/blob/master/ABIs/energy.json), but feel free to use your own.
 
 ## `contracts.load(address, abi)`
 

--- a/developer-resources/index-with-graph-node/index-with-openzeppelin/configure-contracts.md
+++ b/developer-resources/index-with-graph-node/index-with-openzeppelin/configure-contracts.md
@@ -32,7 +32,7 @@ Create a configuration file `vbd-tokens.json` with this information:
 ```
 
 ```shell
-npx graph-compiler \
+npx --package @amxx/graphprotocol-utils -- graph-compiler \
   --config vbd-tokens.json \
   --include node_modules/@openzeppelin/subgraphs/src/datasources \
   --export-schema \


### PR DESCRIPTION
- `events-and-logs`: link text read `gitabihub.com`; href already pointed at `github.com/vechain/b32`. Text now matches.
- `configure-contracts`: `npx graph-compiler` resolves from the npm registry when run outside the project. The bin is provided by `@amxx/graphprotocol-utils` (transitive dep of `@openzeppelin/subgraphs`); pin it with `npx --package`.